### PR TITLE
Using bash syntax in CMake may break compatibility with Windows CMD

### DIFF
--- a/boards/vela/CMakeLists.txt
+++ b/boards/vela/CMakeLists.txt
@@ -87,13 +87,11 @@ file(WRITE ${CMAKE_BINARY_DIR}/advancedFeatures.ini "${emulator_feature_str}")
 add_custom_target(
   gen_images ALL
   DEPENDS nuttx
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  COMMAND genromfs -f ${CMAKE_BINARY_DIR}/vela_system.bin -d
-          ${NUTTX_BOARD_ABS_DIR}/prebuilts/system;
-  COMMAND dd if=/dev/zero of=${CMAKE_BINARY_DIR}/vela_data.bin bs=1M count=256;
-  COMMAND mkfs.fat ${CMAKE_BINARY_DIR}/vela_data.bin;
-  COMMAND mcopy -i ${CMAKE_BINARY_DIR}/vela_data.bin -sv
-          ${NUTTX_BOARD_ABS_DIR}/prebuilts/data/* :: > /dev/null 2>&1;)
+  WORKING_DIRECTORY .
+  COMMAND genromfs -f ${CMAKE_BINARY_DIR}/vela_system.bin -d ${NUTTX_BOARD_ABS_DIR}/prebuilts/system
+  COMMAND dd if=/dev/zero of=${CMAKE_BINARY_DIR}/vela_data.bin bs=1M count=256
+  COMMAND mkfs.fat ${CMAKE_BINARY_DIR}/vela_data.bin
+  COMMAND mcopy -i ${CMAKE_BINARY_DIR}/vela_data.bin -sv ${NUTTX_BOARD_ABS_DIR}/prebuilts/data/ ::)
 
 if(CONFIG_VELA_AP)
   add_custom_target(


### PR DESCRIPTION
…s CMD

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

