### PR TITLE
emulator: add the ${ARG_OPTION} parameter when run the emulator

### DIFF
--- a/boards/vela/prebuilts/tools/run_emulator.sh
+++ b/boards/vela/prebuilts/tools/run_emulator.sh
@@ -208,4 +208,4 @@ QEMU_OPTION="${QEMU_OPTION} \
 -device virtio-9p-device,id=fs0,fsdev=fsdev0,mount_tag=host"
 fi
 
-${EMULATOR_BIN} -vela -avd ${AVD_NAME} -show-kernel $@ ${QEMU_OPTION}
+${EMULATOR_BIN} -vela -avd ${AVD_NAME} -show-kernel $@ ${ARG_OPTION} ${QEMU_OPTION}


### PR DESCRIPTION
for example:
./emulator.sh vela -no-window

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

