### PR TITLE
emulator: Fix compile error

### DIFF
--- a/boards/vela/src/qemu_vela.c
+++ b/boards/vela/src/qemu_vela.c
@@ -251,7 +251,7 @@ static void register_pci_host_from_fdt(const void *fdt)
         }
     }
 
-  pci_ecam_register(&cfg, &io, &mem, &prefetch);
+  pci_ecam_register(0, &cfg, &io, &mem, &prefetch);
 }
 #endif
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

Just as subject, it has compile error without this change.

## Impact
it's a compile error.

## Testing

can pass compile with command: ./build.sh vendor/openvela/boards/vela/configs/qemu-armeabi-v7a-ap -j16
